### PR TITLE
Feature/unetr implementation

### DIFF
--- a/mipcandy_bundles/unetr/__init__.py
+++ b/mipcandy_bundles/unetr/__init__.py
@@ -1,0 +1,3 @@
+from mipcandy_bundles.unetr.unetr import UNETR, make_unetr
+from mipcandy_bundles.unetr.unetr_trainer import UNETRTrainer
+from mipcandy_bundles.unetr.unetr_predictor import UNETRPredictor

--- a/mipcandy_bundles/unetr/unetr.py
+++ b/mipcandy_bundles/unetr/unetr.py
@@ -90,8 +90,7 @@ class UNETR(nn.Module):
         if pos_embed not in ["conv", "perceptron"]:
             raise KeyError(f"Position embedding layer of type {pos_embed} is not supported.")
 
-        # Map old pos_embed parameter to new MONAI ViT parameters
-        proj_type = "conv" if pos_embed == "conv" else "conv"  # perceptron maps to conv in new MONAI
+        proj_type = "conv" if pos_embed == "conv" else "perceptron"
         pos_embed_type = "learnable"
 
         self.num_layers = 12
@@ -207,7 +206,6 @@ class UNETR(nn.Module):
     def load_from(self, weights):
         with torch.no_grad():
             res_weight = weights
-            # copy weights from patch embedding
             for i in weights["state_dict"]:
                 print(i)
             self.vit.patch_embedding.position_embeddings.copy_(
@@ -223,11 +221,9 @@ class UNETR(nn.Module):
                 weights["state_dict"]["module.transformer.patch_embedding.patch_embeddings.1.bias"]
             )
 
-            # copy weights from  encoding blocks (default: num of blocks: 12)
             for bname, block in self.vit.blocks.named_children():
                 print(block)
                 block.loadFrom(weights, n_block=bname)
-            # last norm layer of transformer
             self.vit.norm.weight.copy_(weights["state_dict"]["module.transformer.norm.weight"])
             self.vit.norm.bias.copy_(weights["state_dict"]["module.transformer.norm.bias"])
 

--- a/mipcandy_bundles/unetr/unetr.py
+++ b/mipcandy_bundles/unetr/unetr.py
@@ -13,8 +13,6 @@
 # Original source: https://github.com/Project-MONAI/research-contributions/blob/main/UNETR/BTCV/networks/unetr.py
 # Modifications: Adapted for MIPCandy framework with LayerT integration and MONAI 1.5.0 compatibility
 
-from typing import Tuple, Union
-
 import torch
 import torch.nn as nn
 from mipcandy import LayerT
@@ -34,13 +32,13 @@ class UNETR(nn.Module):
         self,
         in_channels: int,
         out_channels: int,
-        img_size: Tuple[int, int, int],
+        img_size: tuple[int, int, int],
         feature_size: int = 16,
         hidden_size: int = 768,
         mlp_dim: int = 3072,
         num_heads: int = 12,
         pos_embed: str = "perceptron",
-        norm_name: Union[Tuple, str] = "instance",
+        norm_name: tuple | str = "instance",
         conv_block: bool = False,
         res_block: bool = True,
         dropout_rate: float = 0.0,
@@ -250,10 +248,10 @@ class UNETR(nn.Module):
         logits = self.out(out)
         return logits
 
-def make_unetr(in_channels: int, out_channels: int, img_size: Tuple[int, int, int],
+def make_unetr(in_channels: int, out_channels: int, img_size: tuple[int, int, int],
                *, feature_size: int = 16, hidden_size: int = 768, mlp_dim: int = 3072,
                num_heads: int = 12, pos_embed: str = "perceptron",
-               norm_name: Union[Tuple, str] = "instance", conv_block: bool = False,
+               norm_name: tuple | str = "instance", conv_block: bool = False,
                res_block: bool = True, dropout_rate: float = 0.0) -> UNETR:
     return UNETR(
         in_channels=in_channels,

--- a/mipcandy_bundles/unetr/unetr.py
+++ b/mipcandy_bundles/unetr/unetr.py
@@ -1,0 +1,280 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is a modified version of the original UNETR implementation.
+# Original source: https://github.com/Project-MONAI/research-contributions/blob/main/UNETR/BTCV/networks/unetr.py
+# Modifications: Adapted for MIPCandy framework with LayerT integration and MONAI 1.5.0 compatibility
+
+from typing import Tuple, Union
+
+import torch
+import torch.nn as nn
+from mipcandy import LayerT
+
+from monai.networks.blocks import UnetrBasicBlock, UnetrPrUpBlock, UnetrUpBlock
+from monai.networks.blocks.dynunet_block import UnetOutBlock
+from monai.networks.nets import ViT
+
+
+class UNETR(nn.Module):
+    """
+    UNETR based on: "Hatamizadeh et al.,
+    UNETR: Transformers for 3D Medical Image Segmentation <https://arxiv.org/abs/2103.10504>"
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        img_size: Tuple[int, int, int],
+        feature_size: int = 16,
+        hidden_size: int = 768,
+        mlp_dim: int = 3072,
+        num_heads: int = 12,
+        pos_embed: str = "perceptron",
+        norm_name: Union[Tuple, str] = "instance",
+        conv_block: bool = False,
+        res_block: bool = True,
+        dropout_rate: float = 0.0,
+        *,
+        vit: LayerT = LayerT(ViT),
+        encoder1: LayerT = LayerT(UnetrBasicBlock),
+        encoder2: LayerT = LayerT(UnetrPrUpBlock),
+        encoder3: LayerT = LayerT(UnetrPrUpBlock),
+        encoder4: LayerT = LayerT(UnetrPrUpBlock),
+        decoder5: LayerT = LayerT(UnetrUpBlock),
+        decoder4: LayerT = LayerT(UnetrUpBlock),
+        decoder3: LayerT = LayerT(UnetrUpBlock),
+        decoder2: LayerT = LayerT(UnetrUpBlock),
+        out: LayerT = LayerT(UnetOutBlock)
+    ) -> None:
+        """
+        Args:
+            in_channels: dimension of input channels.
+            out_channels: dimension of output channels.
+            img_size: dimension of input image.
+            feature_size: dimension of network feature size.
+            hidden_size: dimension of hidden layer.
+            mlp_dim: dimension of feedforward layer.
+            num_heads: number of attention heads.
+            pos_embed: position embedding layer type.
+            norm_name: feature normalization type and arguments.
+            conv_block: bool argument to determine if convolutional block is used.
+            res_block: bool argument to determine if residual block is used.
+            dropout_rate: faction of the input units to drop.
+
+        Examples::
+
+            # for single channel input 4-channel output with patch size of (96,96,96), feature size of 32 and batch norm
+            >>> net = UNETR(in_channels=1, out_channels=4, img_size=(96,96,96), feature_size=32, norm_name='batch')
+
+            # for 4-channel input 3-channel output with patch size of (128,128,128), conv position embedding and instance norm
+            >>> net = UNETR(in_channels=4, out_channels=3, img_size=(128,128,128), pos_embed='conv', norm_name='instance')
+
+        """
+
+        super().__init__()
+
+        if not (0 <= dropout_rate <= 1):
+            raise AssertionError("dropout_rate should be between 0 and 1.")
+
+        if hidden_size % num_heads != 0:
+            raise AssertionError("hidden size should be divisible by num_heads.")
+
+        if pos_embed not in ["conv", "perceptron"]:
+            raise KeyError(f"Position embedding layer of type {pos_embed} is not supported.")
+
+        # Map old pos_embed parameter to new MONAI ViT parameters
+        proj_type = "conv" if pos_embed == "conv" else "conv"  # perceptron maps to conv in new MONAI
+        pos_embed_type = "learnable"
+
+        self.num_layers = 12
+        self.patch_size = (16, 16, 16)
+        self.feat_size = (
+            img_size[0] // self.patch_size[0],
+            img_size[1] // self.patch_size[1],
+            img_size[2] // self.patch_size[2],
+        )
+        self.hidden_size = hidden_size
+        self.classification = False
+        self.vit = vit.assemble(
+            in_channels=in_channels,
+            img_size=img_size,
+            patch_size=self.patch_size,
+            hidden_size=hidden_size,
+            mlp_dim=mlp_dim,
+            num_layers=self.num_layers,
+            num_heads=num_heads,
+            proj_type=proj_type,
+            pos_embed_type=pos_embed_type,
+            classification=self.classification,
+            dropout_rate=dropout_rate,
+        )
+        self.encoder1 = encoder1.assemble(
+            spatial_dims=3,
+            in_channels=in_channels,
+            out_channels=feature_size,
+            kernel_size=3,
+            stride=1,
+            norm_name=norm_name,
+            res_block=res_block,
+        )
+        self.encoder2 = encoder2.assemble(
+            spatial_dims=3,
+            in_channels=hidden_size,
+            out_channels=feature_size * 2,
+            num_layer=2,
+            kernel_size=3,
+            stride=1,
+            upsample_kernel_size=2,
+            norm_name=norm_name,
+            conv_block=conv_block,
+            res_block=res_block,
+        )
+        self.encoder3 = encoder3.assemble(
+            spatial_dims=3,
+            in_channels=hidden_size,
+            out_channels=feature_size * 4,
+            num_layer=1,
+            kernel_size=3,
+            stride=1,
+            upsample_kernel_size=2,
+            norm_name=norm_name,
+            conv_block=conv_block,
+            res_block=res_block,
+        )
+        self.encoder4 = encoder4.assemble(
+            spatial_dims=3,
+            in_channels=hidden_size,
+            out_channels=feature_size * 8,
+            num_layer=0,
+            kernel_size=3,
+            stride=1,
+            upsample_kernel_size=2,
+            norm_name=norm_name,
+            conv_block=conv_block,
+            res_block=res_block,
+        )
+        self.decoder5 = decoder5.assemble(
+            spatial_dims=3,
+            in_channels=hidden_size,
+            out_channels=feature_size * 8,
+            kernel_size=3,
+            upsample_kernel_size=2,
+            norm_name=norm_name,
+            res_block=res_block,
+        )
+        self.decoder4 = decoder4.assemble(
+            spatial_dims=3,
+            in_channels=feature_size * 8,
+            out_channels=feature_size * 4,
+            kernel_size=3,
+            upsample_kernel_size=2,
+            norm_name=norm_name,
+            res_block=res_block,
+        )
+        self.decoder3 = decoder3.assemble(
+            spatial_dims=3,
+            in_channels=feature_size * 4,
+            out_channels=feature_size * 2,
+            kernel_size=3,
+            upsample_kernel_size=2,
+            norm_name=norm_name,
+            res_block=res_block,
+        )
+        self.decoder2 = decoder2.assemble(
+            spatial_dims=3,
+            in_channels=feature_size * 2,
+            out_channels=feature_size,
+            kernel_size=3,
+            upsample_kernel_size=2,
+            norm_name=norm_name,
+            res_block=res_block,
+        )
+        self.out = out.assemble(spatial_dims=3, in_channels=feature_size, out_channels=out_channels)
+
+    def proj_feat(self, x, hidden_size, feat_size):
+        x = x.view(x.size(0), feat_size[0], feat_size[1], feat_size[2], hidden_size)
+        x = x.permute(0, 4, 1, 2, 3).contiguous()
+        return x
+
+    def load_from(self, weights):
+        with torch.no_grad():
+            res_weight = weights
+            # copy weights from patch embedding
+            for i in weights["state_dict"]:
+                print(i)
+            self.vit.patch_embedding.position_embeddings.copy_(
+                weights["state_dict"]["module.transformer.patch_embedding.position_embeddings_3d"]
+            )
+            self.vit.patch_embedding.cls_token.copy_(
+                weights["state_dict"]["module.transformer.patch_embedding.cls_token"]
+            )
+            self.vit.patch_embedding.patch_embeddings[1].weight.copy_(
+                weights["state_dict"]["module.transformer.patch_embedding.patch_embeddings.1.weight"]
+            )
+            self.vit.patch_embedding.patch_embeddings[1].bias.copy_(
+                weights["state_dict"]["module.transformer.patch_embedding.patch_embeddings.1.bias"]
+            )
+
+            # copy weights from  encoding blocks (default: num of blocks: 12)
+            for bname, block in self.vit.blocks.named_children():
+                print(block)
+                block.loadFrom(weights, n_block=bname)
+            # last norm layer of transformer
+            self.vit.norm.weight.copy_(weights["state_dict"]["module.transformer.norm.weight"])
+            self.vit.norm.bias.copy_(weights["state_dict"]["module.transformer.norm.bias"])
+
+    def forward(self, x_in):
+        x, hidden_states_out = self.vit(x_in)
+        enc1 = self.encoder1(x_in)
+        x2 = hidden_states_out[3]
+        enc2 = self.encoder2(self.proj_feat(x2, self.hidden_size, self.feat_size))
+        x3 = hidden_states_out[6]
+        enc3 = self.encoder3(self.proj_feat(x3, self.hidden_size, self.feat_size))
+        x4 = hidden_states_out[9]
+        enc4 = self.encoder4(self.proj_feat(x4, self.hidden_size, self.feat_size))
+        dec4 = self.proj_feat(x, self.hidden_size, self.feat_size)
+        dec3 = self.decoder5(dec4, enc4)
+        dec2 = self.decoder4(dec3, enc3)
+        dec1 = self.decoder3(dec2, enc2)
+        out = self.decoder2(dec1, enc1)
+        logits = self.out(out)
+        return logits
+
+def make_unetr(in_channels: int, out_channels: int, img_size: Tuple[int, int, int],
+               *, feature_size: int = 16, hidden_size: int = 768, mlp_dim: int = 3072,
+               num_heads: int = 12, pos_embed: str = "perceptron",
+               norm_name: Union[Tuple, str] = "instance", conv_block: bool = False,
+               res_block: bool = True, dropout_rate: float = 0.0) -> UNETR:
+    return UNETR(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        img_size=img_size,
+        feature_size=feature_size,
+        hidden_size=hidden_size,
+        mlp_dim=mlp_dim,
+        num_heads=num_heads,
+        pos_embed=pos_embed,
+        norm_name=norm_name,
+        conv_block=conv_block,
+        res_block=res_block,
+        dropout_rate=dropout_rate
+    )
+
+
+if __name__ == "__main__":
+    from mipcandy import sanity_check
+
+    model = make_unetr(3, 3, (64, 64, 64), feature_size=16)
+    result = sanity_check(model, (3, 64, 64, 64))
+    print(result)
+    print(result.output.shape)

--- a/mipcandy_bundles/unetr/unetr_predictor.py
+++ b/mipcandy_bundles/unetr/unetr_predictor.py
@@ -1,0 +1,18 @@
+from typing import override, Mapping, Any
+
+from mipcandy import Predictor
+from torch import nn
+
+from mipcandy_bundles.unetr.unetr import make_unetr
+
+
+class UNETRPredictor(Predictor):
+    in_ch: int = 1
+    num_classes: int = 1
+    img_size: tuple[int, int, int] = (96, 96, 96)
+
+    @override
+    def build_network(self, checkpoint: Mapping[str, Any]) -> nn.Module:
+        model = make_unetr(self.in_ch, self.num_classes, self.img_size)
+        model.load_state_dict(checkpoint)
+        return model

--- a/mipcandy_bundles/unetr/unetr_trainer.py
+++ b/mipcandy_bundles/unetr/unetr_trainer.py
@@ -1,0 +1,14 @@
+from typing import override
+
+from mipcandy import SegmentationTrainer
+from torch import nn
+
+from mipcandy_bundles.unetr.unetr import make_unetr
+
+
+class UNETRTrainer(SegmentationTrainer):
+    @override
+    def build_network(self, example_shape: tuple[int, ...]) -> nn.Module:
+        if len(example_shape) != 4:  # [C, D, H, W]
+            raise ValueError(f"UNETR requires 3D input, got shape {example_shape}")
+        return make_unetr(example_shape[0], self.num_classes, example_shape[1:])

--- a/mipcandy_bundles/unetr/unetr_trainer.py
+++ b/mipcandy_bundles/unetr/unetr_trainer.py
@@ -9,6 +9,6 @@ from mipcandy_bundles.unetr.unetr import make_unetr
 class UNETRTrainer(SegmentationTrainer):
     @override
     def build_network(self, example_shape: tuple[int, ...]) -> nn.Module:
-        if len(example_shape) != 4:  # [C, D, H, W]
+        if len(example_shape) != 4:
             raise ValueError(f"UNETR requires 3D input, got shape {example_shape}")
         return make_unetr(example_shape[0], self.num_classes, example_shape[1:])


### PR DESCRIPTION
This pull request adds a new UNETR model bundle for the MIPCandy framework, providing a MONAI-compatible 3D transformer-based segmentation network along with associated trainer and predictor classes. The main changes include the introduction of a configurable and modular `UNETR` model, as well as supporting components to enable training and inference within the framework.

**New UNETR model integration:**

* Added a new `UNETR` class in `unetr.py`, adapted from the MONAI implementation, with LayerT-based modularity and compatibility with MONAI 1.5.0. Includes a factory function `make_unetr` and a main block for standalone testing.
* Introduced `UNETRTrainer` in `unetr_trainer.py`, a `SegmentationTrainer` subclass that builds the network using the new UNETR model and validates input shape for 3D data.
* Added `UNETRPredictor` in `unetr_predictor.py`, a `Predictor` subclass that loads the UNETR model and checkpoint for inference.

fixed #10 